### PR TITLE
Remove tifffile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ packaging
 pathlib;python_version<"3.0"
 numpy
 requests
-tifffile
 imageio

--- a/slicedimage/_formats.py
+++ b/slicedimage/_formats.py
@@ -1,24 +1,11 @@
 import enum
-from pathlib import Path
-
-from ._compat import fspath
-
-
-def to_file_obj_or_str(obj):
-    """skimage methods only accept a file-like object or a string path.  This method converts a
-    file-like object, str, or pathlib.Path into a file-like object or a string path."""
-    if isinstance(obj, Path):
-        return fspath(obj)
-    return obj
 
 
 def tiff_reader():
-    # lazy load tifffile
-    import tifffile
+    from imageio import imread
 
     def reader(f):
-        with tifffile.TiffFile(to_file_obj_or_str(f)) as tiff:
-            return tiff.asarray(maxworkers=1)
+        return imread(f, format="tiff")
 
     return reader
 
@@ -26,7 +13,10 @@ def tiff_reader():
 def png_reader():
     from imageio import imread
 
-    return imread
+    def reader(f):
+        return imread(f, format="png")
+
+    return reader
 
 
 def numpy_reader():
@@ -41,12 +31,10 @@ def tiff_writer():
     Return a method that accepts (file, array) and saves it to the file.  File may be a file-like
     object, str, or pathlib.Path.
     """
-    # lazy load tifffile
-    import tifffile
+    from imageio import imwrite
 
     def writer(f, arr):
-        with tifffile.TiffWriter(to_file_obj_or_str(f)) as tiff:
-            return tiff.save(arr, datetime=None)
+        imwrite(f, arr, format="tiff")
 
     return writer
 
@@ -55,7 +43,7 @@ def png_writer():
     from imageio import imwrite
 
     def writer(f, arr):
-        return imwrite(to_file_obj_or_str(f), arr, format='png')
+        return imwrite(f, arr, format="png")
 
     return writer
 

--- a/tests/io_/v0_0_0/test_reader.py
+++ b/tests/io_/v0_0_0/test_reader.py
@@ -6,7 +6,6 @@ import unittest
 from pathlib import Path
 
 import imageio
-import tifffile
 import numpy as np
 from slicedimage._compat import fspath
 
@@ -66,8 +65,7 @@ class TestFormats(unittest.TestCase):
             tempdir_path = Path(tempdir)
             # write the tiff file
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            with tifffile.TiffWriter(os.path.join(tempdir, "tile.tiff")) as tiff:
-                tiff.save(data)
+            imageio.imwrite(os.path.join(tempdir, "tile.tiff"), data, format="tiff")
 
             # TODO: (ttung) We should really be producing a tileset programmatically and writing it
             # disk.  However, our current write path only produces numpy output files.

--- a/tests/io_/v0_0_0/test_write.py
+++ b/tests/io_/v0_0_0/test_write.py
@@ -5,8 +5,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import tifffile
 import numpy as np
+from imageio import imwrite
 from slicedimage._compat import fspath
 
 import slicedimage
@@ -133,8 +133,7 @@ class TestWrite(unittest.TestCase):
             tempdir_path = Path(tempdir)
             file_path = tempdir_path / "tile.tiff"
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            with tifffile.TiffWriter(fspath(file_path)) as tiff:
-                tiff.save(data)
+            imwrite(file_path, data, format="tiff")
             with open(fspath(file_path), "rb") as fh:
                 checksum = hashlib.sha256(fh.read()).hexdigest()
 

--- a/tests/io_/v0_1_0/test_reader.py
+++ b/tests/io_/v0_1_0/test_reader.py
@@ -6,7 +6,6 @@ import unittest
 from pathlib import Path
 
 import imageio
-import tifffile
 import numpy as np
 from slicedimage._compat import fspath
 
@@ -66,8 +65,7 @@ class TestFormats(unittest.TestCase):
             tempdir_path = Path(tempdir)
             # write the tiff file
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
-            with tifffile.TiffWriter(os.path.join(tempdir, "tile.tiff")) as tiff:
-                tiff.save(data)
+            imageio.imwrite(os.path.join(tempdir, "tile.tiff"), data, format="tiff")
 
             # TODO: (ttung) We should really be producing a tileset programmatically and writing it
             # disk.  However, our current write path only produces numpy output files.

--- a/tests/io_/v0_1_0/test_write.py
+++ b/tests/io_/v0_1_0/test_write.py
@@ -6,8 +6,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import tifffile
 import numpy as np
+from imageio import imwrite
 from slicedimage._compat import fspath
 
 import slicedimage
@@ -134,8 +134,7 @@ class TestWrite(unittest.TestCase):
             tempdir_path = Path(tempdir)
             data = np.random.randint(0, 65535, size=(120, 80), dtype=np.uint16)
             file_path = os.path.join(tempdir, "tile.tiff")
-            with tifffile.TiffWriter(file_path) as tiff:
-                tiff.save(data)
+            imwrite(file_path, data, format="tiff")
             with open(file_path, "rb") as fh:
                 checksum = hashlib.sha256(fh.read()).hexdigest()
 


### PR DESCRIPTION
imageio supports both tiffs and pngs, so there isn't a point in having both.